### PR TITLE
docs(readme): add initial project description and vision for Grove

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# grove
+# 🌳 Grove
+
+**Grove** est un gestionnaire de *workspace* en ligne de commande (CLI).  
+Son nom vient de l'anglais **"grove"**, qui désigne un petit bois cultivé, un écosystème d'arbres vivant, structuré et harmonieux.
+
+À l'image d'une arborescence de projet, **Grove** a pour vocation d'accompagner la vie des projets du début à la fin :
+- Depuis leur **germination** (initialisation),
+- En passant par leur **croissance** (ajout de modules, configuration, structuration),
+- Jusqu’à leur **maturité** ou leur **archivage**.
+
+---
+
+## 📦 État du projet
+
+> Le projet est en cours de germination. 🌱  
+Aucune fonctionnalité n’est encore disponible.
+
+L’outillage, la structure interne, et la vision à long terme sont en cours de définition.  
+Suivez le développement pour voir Grove prendre racine !
+
+---
+
+## ✨ Objectif à terme
+
+Créer une CLI modulaire, intelligente et vivante qui permet de :
+
+- Initialiser un projet selon différents profils
+- Ajouter dynamiquement des composants (Git, Docker, CI, Makefile…)
+- Diagnostiquer l’état d’un projet et le faire évoluer
+- Gérer des workspaces entiers comme un **petit écosystème logiciel**
+
+---
+
+## 🪴 Pourquoi ce nom ?
+
+> **“Every great project begins with a Grove.”**
+
+- Un **grove**, ce n’est pas une forêt sauvage.
+- C’est un **lieu structuré**, **pensé**, **entretenu**.
+- C’est exactement ce qu’un projet mérite :  
+  un espace organisé, vivant, et façonné avec soin.
+
+---
+
+## 🧙 Conçu par
+
+**Karamir**


### PR DESCRIPTION
This is the starting point of the Grove project.

It introduces the project's name, its symbolic connection to natural ecosystems, and outlines Grove's purpose as a CLI-based workspace manager designed to support the entire lifecycle of a project — from its initialization to its maturity or archival.

Nothing is functional yet, but the vision is now planted like a seed.

Let the forest grow 🌱